### PR TITLE
Fix font loading in slides

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap');
+
 body, html {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- add a Google Fonts import for Noto Sans JP so the correct font loads

## Testing
- `npx -y html-validator-cli index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846cc77b5e0832fa59f5f77419f0960