### PR TITLE
Add royalblue color to final slide heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 
   <!-- スライド15 -->
   <section data-background-image="img/nishiko.jpg" data-background-size="cover" data-background-transition="zoom">
-    <h2 class="fade-text">この研修で得られる学び</h2>
+    <h2 class="fade-text" style="color: royalblue;">この研修で得られる学び</h2>
     <p class="fade-text">異文化でのチーム行動によりリサーチ力・判断力・協調性を高める</p>
     <p class="fade-text">AI × 都市 × 社会制度を現地で体感</p>
     <p class="fade-text">スマートシティの日本活用を考察</p>


### PR DESCRIPTION
## Summary
- style the heading on the final slide with a royal blue color

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847c07e5a0c832f9eb7a22f933eaeb9